### PR TITLE
Swap library RPC methods to use folders instead of directories

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -8,3 +8,5 @@ breaking:
 modules:
   - path: .
     name: buf.build/listenup/listenup
+deps:
+  - buf.build/googleapis/googleapis

--- a/listenup/library/v1/library.proto
+++ b/listenup/library/v1/library.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package listenup.library.v1;
 
 import "google/protobuf/timestamp.proto";
+import "listenup/folder/v1/folder.proto";
 
 // A library is a collection of directories and associated settings and users.
 message Library {
@@ -53,7 +54,7 @@ message ListLibrariesResponse {
 
 message CreateLibraryRequest {
   string name = 1;
-  repeated Directory directories = 2;
+  repeated listenup.folder.v1.Folder folders = 2;
   LibrarySettings settings = 3;
 }
 
@@ -66,7 +67,7 @@ message LibrarySettings {}
 
 message AddDirectoryToLibraryRequest {
   string library_id = 1;
-  Directory directory = 2;
+  listenup.folder.v1.Folder directory = 2;
 }
 
 message AddDirectoryToLibraryResponse {


### PR DESCRIPTION
Initially all the of the request types for creating a library or adding a folder to a library used the Directory type.  But we've since added a folder type that represents the sending data and the Directory type which represents the response type.